### PR TITLE
updated das-platform-building-blocks to 2.1.28 & das-platform automation to 5.1.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,13 +17,13 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.1.0
+    ref: refs/tags/2.1.28
     endpoint: SkillsFundingAgency
   - repository: self
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.4
+    ref: refs/tags/5.1.8
     endpoint: SkillsFundingAgency
 
 stages:

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -20,6 +20,7 @@ jobs:
   - template: azure-pipelines-templates/build/step/app-build.yml@das-platform-building-blocks
     parameters:
       SonarCloudProjectKey: SkillsFundingAgency_das-api-stub
+      ContinueOnVulnerablePackageScanError: true
 
   - task: DotNetCoreCLI@2
     displayName: Publish Stub Api


### PR DESCRIPTION
Upgrading seems to have had no adverse effects:
https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_build/results?buildId=814363&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76

Deployment is failing due to known issue.